### PR TITLE
온보딩 상단 Indicator 및 OnboardingView 리펙토링

### DIFF
--- a/LoveBird/Sources/Extension/Page+Extension.swift
+++ b/LoveBird/Sources/Extension/Page+Extension.swift
@@ -8,7 +8,30 @@
 import SwiftUIPager
 
 extension Page {
-  var isNickname: Bool {
-    return self.index == 0
+  enum Onboarding: Int, CaseIterable {
+    case email
+    case nickname
+    case profileImage
+    case birth
+    case gender
+    case anniversary
+  }
+
+  var state: Onboarding {
+    return Onboarding(rawValue: self.index) ?? .email
+  }
+
+  var isFisrt: Bool {
+    return self.index == Onboarding.email.rawValue
+  }
+
+  var isLast: Bool {
+    return self.index == Onboarding.anniversary.rawValue
+  }
+}
+
+extension Page: Equatable {
+  public static func == (lhs: Page, rhs: Page) -> Bool {
+    lhs.index == rhs.index
   }
 }

--- a/LoveBird/Sources/Extension/Page+Extension.swift
+++ b/LoveBird/Sources/Extension/Page+Extension.swift
@@ -15,6 +15,40 @@ extension Page {
     case birth
     case gender
     case anniversary
+
+    var title: String {
+      switch self {
+      case .email:
+        return String(resource: R.string.localizable.onboarding_email_title)
+      case .nickname:
+        return String(resource: R.string.localizable.onboarding_nickname_title)
+      case .profileImage:
+        return String(resource: R.string.localizable.onboarding_profile_title)
+      case .birth:
+        return String(resource: R.string.localizable.onboarding_birthdate_title)
+      case .gender:
+        return String(resource: R.string.localizable.onboarding_gender_title)
+      case .anniversary:
+        return String(resource: R.string.localizable.onboarding_date_title)
+      }
+    }
+
+    var description: String {
+      switch self {
+      case .email:
+        return String(resource: R.string.localizable.onboarding_email_description)
+      case .nickname:
+        return String(resource: R.string.localizable.onboarding_nickname_description)
+      case .profileImage:
+        return String(resource: R.string.localizable.onboarding_profile_description)
+      case .birth:
+        return String(resource: R.string.localizable.onboarding_birthdate_description)
+      case .gender:
+        return String(resource: R.string.localizable.onboarding_gender_description)
+      case .anniversary:
+        return String(resource: R.string.localizable.onboarding_date_description)
+      }
+    }
   }
 
   var state: Onboarding {
@@ -31,6 +65,7 @@ extension Page {
 }
 
 extension Page: Equatable {
+  // Page가 Class이므로 사실상 true만 return된다.
   public static func == (lhs: Page, rhs: Page) -> Bool {
     lhs.index == rhs.index
   }

--- a/LoveBird/Sources/Root/Onboarding/OnboardingBirthDateView.swift
+++ b/LoveBird/Sources/Root/Onboarding/OnboardingBirthDateView.swift
@@ -13,7 +13,7 @@ struct OnboardingBirthDateView: View {
   let store: StoreOf<OnboardingCore>
   
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       ZStack {
         VStack {
           HStack(alignment: .center, spacing: 8) {

--- a/LoveBird/Sources/Root/Onboarding/OnboardingBirthDateView.swift
+++ b/LoveBird/Sources/Root/Onboarding/OnboardingBirthDateView.swift
@@ -16,21 +16,6 @@ struct OnboardingBirthDateView: View {
     WithViewStore(self.store) { viewStore in
       ZStack {
         VStack {
-          Spacer().frame(height: 24)
-          Text(R.string.localizable.onboarding_birthdate_title)
-            .font(.pretendard(size: 20, weight: .bold))
-            .foregroundColor(.black)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.leading, 16)
-          Text(R.string.localizable.onboarding_birthdate_description)
-            .font(.pretendard(size: 16, weight: .regular))
-            .foregroundColor(Color(R.color.gray07))
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.top, 12)
-            .padding(.leading, 16)
-          Spacer()
-            .frame(height: 48)
-          
           HStack(alignment: .center, spacing: 8) {
             Text(String(viewStore.birthdateYear))
               .font(.pretendard(size: 18))

--- a/LoveBird/Sources/Root/Onboarding/OnboardingCore.swift
+++ b/LoveBird/Sources/Root/Onboarding/OnboardingCore.swift
@@ -23,25 +23,39 @@ struct OnboardingCore: ReducerProtocol {
   }
   
   struct State: Equatable {
+    // common
     var page: Page = .first()
     var pageIdx: Int = Constant.nicknamePageIdx
-    var nickname: String = ""
     var textFieldState: TextFieldState = .none
     var buttonClickState: ButtonClickState = .notClicked
     var showBottomSheet = false
-    var gender = ""
+
+    // page1
+    var email: String = ""
+
+    // page2
+    var nickname: String = ""
+
+    // page3
+    var profileImage: UIImage?
+
+    // page4
+    var birthday: String? = ""
     var birthdateYear: Int = Date().year
     var birthdateMonth: Int = Date().month
     var birthdateDay: Int = Date().day
-    var birthday: String? = ""
+
+    // page5
+    var gender = ""
+
+    // page6
     var firstday: String? = ""
     var firstdateYear: Int = Date().year
     var firstdateMonth: Int = Date().month
     var firstdateDay: Int = Date().day
-    var email: String = ""
+
     var invitationCode: String = "임시코드임니다"
     var invitationInputCode: String = ""
-    var profileImage: UIImage?
   }
   
   enum Action: Equatable {
@@ -66,7 +80,6 @@ struct OnboardingCore: ReducerProtocol {
     case registerProfileResponse(TaskResult<Profile>)
     case tryLinkResponse(TaskResult<TryLinkResponse>)
     case imageSelected(UIImage?)
-    case circleClicked(Int)
     case invitationcodeEdited(String)
     case invitationViewLoaded(String)
     case tryLink(String)
@@ -83,10 +96,6 @@ struct OnboardingCore: ReducerProtocol {
   var body: some ReducerProtocol<State, Action> {
     Reduce { state, action in
       switch action {
-      case .circleClicked(let index):
-        state.page.update(.move(increment: index))
-        return .none
-
       case .nextTapped, .nextButtonTapped:
         state.page.update(.next)
         state.pageIdx = 1
@@ -97,9 +106,7 @@ struct OnboardingCore: ReducerProtocol {
         return .none
 
       case .previousTapped:
-        if state.page.index == 0 {
-          return .none
-        } else {
+        if !state.page.isFisrt {
           state.page.update(.previous)
         }
         return .none
@@ -256,11 +263,5 @@ struct OnboardingCore: ReducerProtocol {
         return .none
       }
     }
-  }
-}
-
-extension Page: Equatable {
-  public static func == (lhs: Page, rhs: Page) -> Bool {
-    lhs.index == rhs.index
   }
 }

--- a/LoveBird/Sources/Root/Onboarding/OnboardingCore.swift
+++ b/LoveBird/Sources/Root/Onboarding/OnboardingCore.swift
@@ -25,7 +25,7 @@ struct OnboardingCore: ReducerProtocol {
   struct State: Equatable {
     // common
     var page: Page = .first()
-    var pageIdx: Int = Constant.nicknamePageIdx
+    var pageState: Page.Onboarding = .email
     var textFieldState: TextFieldState = .none
     var buttonClickState: ButtonClickState = .notClicked
     var showBottomSheet = false
@@ -97,8 +97,10 @@ struct OnboardingCore: ReducerProtocol {
     Reduce { state, action in
       switch action {
       case .nextTapped, .nextButtonTapped:
-        state.page.update(.next)
-        state.pageIdx = 1
+        if !state.page.isLast {
+          state.page.update(.next)
+          state.pageState = state.page.state
+        }
         return .none
 
       case .textFieldStateChanged(let textFieldState):
@@ -108,6 +110,7 @@ struct OnboardingCore: ReducerProtocol {
       case .previousTapped:
         if !state.page.isFisrt {
           state.page.update(.previous)
+          state.pageState = state.page.state
         }
         return .none
 
@@ -192,7 +195,6 @@ struct OnboardingCore: ReducerProtocol {
         
       case .skipBirthdate:
         state.page.update(.next)
-        state.pageIdx = 1
         state.birthday = nil
         return .none
         
@@ -202,7 +204,6 @@ struct OnboardingCore: ReducerProtocol {
         let birthday = state.birthdateDay
 
         state.page.update(.next)
-        state.pageIdx = 1
         state.birthday = String(format: "%04d-%02d-%02d", birthyear, birthmonth, birthday)
         return .none
         

--- a/LoveBird/Sources/Root/Onboarding/OnboardingDateView.swift
+++ b/LoveBird/Sources/Root/Onboarding/OnboardingDateView.swift
@@ -13,23 +13,9 @@ struct OnboardingDateView: View {
   let store: StoreOf<OnboardingCore>
   
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       ZStack {
         VStack {
-          Spacer().frame(height: 24)
-          Text(R.string.localizable.onboarding_date_title)
-            .font(.pretendard(size: 20, weight: .bold))
-            .foregroundColor(.black)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.leading, 16)
-          Text(R.string.localizable.onboarding_date_description)
-            .font(.pretendard(size: 16, weight: .regular))
-            .foregroundColor(Color(R.color.gray07))
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.top, 12)
-            .padding(.leading, 16)
-          Spacer().frame(height: 48)
-          
           HStack(alignment: .center, spacing: 8) {
             Text(String(viewStore.firstdateYear))
               .font(.pretendard(size: 18))

--- a/LoveBird/Sources/Root/Onboarding/OnboardingEmailView.swift
+++ b/LoveBird/Sources/Root/Onboarding/OnboardingEmailView.swift
@@ -15,25 +15,8 @@ struct OnboardingEmailView: View {
   @StateObject private var keyboard = KeyboardResponder()
   
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       VStack {
-        Spacer().frame(height: 24)
-        
-        Text(R.string.localizable.onboarding_email_title)
-          .font(.pretendard(size: 20, weight: .bold))
-          .foregroundColor(.black)
-          .frame(maxWidth: .infinity, alignment: .leading)
-          .padding(.leading, 16)
-
-        Text(R.string.localizable.onboarding_email_description)
-          .font(.pretendard(size: 16, weight: .regular))
-          .foregroundColor(Color(R.color.gray07))
-          .frame(maxWidth: .infinity, alignment: .leading)
-          .padding(.top, 12)
-          .padding(.leading, 16)
-        
-        Spacer().frame(height: 48)
-        
         TextField("love@bird.com", text: viewStore.binding(get: \.email, send: OnboardingCore.Action.emailEdited))
           .font(.pretendard(size: 18, weight: .regular))
           .textContentType(.emailAddress)

--- a/LoveBird/Sources/Root/Onboarding/OnboardingGenderView.swift
+++ b/LoveBird/Sources/Root/Onboarding/OnboardingGenderView.swift
@@ -16,22 +16,6 @@ struct OnboardingGenderView: View {
     WithViewStore(self.store) { viewStore in
       ZStack {
         VStack {
-          Spacer().frame(height: 24)
-          Text(R.string.localizable.onboarding_gender_title)
-            .font(.pretendard(size: 20, weight: .bold))
-            .foregroundColor(.black)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.leading, 16)
-          Text(R.string.localizable.onboarding_gender_description)
-            .font(.pretendard(size: 16, weight: .regular))
-            .foregroundColor(Color(R.color.gray07))
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.top, 12)
-            .padding(.leading, 16)
-          
-          Spacer()
-            .frame(height: 48)
-          
           VStack(alignment: .leading) {
             TouchableStack {
               HStack {

--- a/LoveBird/Sources/Root/Onboarding/OnboardingGenderView.swift
+++ b/LoveBird/Sources/Root/Onboarding/OnboardingGenderView.swift
@@ -13,7 +13,7 @@ struct OnboardingGenderView: View {
   let store: StoreOf<OnboardingCore>
   
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       ZStack {
         VStack {
           VStack(alignment: .leading) {

--- a/LoveBird/Sources/Root/Onboarding/OnboardingNicknameView.swift
+++ b/LoveBird/Sources/Root/Onboarding/OnboardingNicknameView.swift
@@ -15,7 +15,7 @@ struct OnboardingNicknameView: View {
   @StateObject private var keyboard = KeyboardResponder()
   
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       VStack {
         TextField("ex. 러버", text: viewStore.binding(get: \.nickname, send: OnboardingCore.Action.nicknameEdited))
           .font(.pretendard(size: 18, weight: .regular))

--- a/LoveBird/Sources/Root/Onboarding/OnboardingNicknameView.swift
+++ b/LoveBird/Sources/Root/Onboarding/OnboardingNicknameView.swift
@@ -17,23 +17,6 @@ struct OnboardingNicknameView: View {
   var body: some View {
     WithViewStore(self.store) { viewStore in
       VStack {
-        Spacer().frame(height: 24)
-        
-        Text(R.string.localizable.onboarding_nickname_title)
-          .font(.pretendard(size: 20, weight: .bold))
-          .foregroundColor(.black)
-          .frame(maxWidth: .infinity, alignment: .leading)
-          .padding(.leading, 16)
-        
-        Text(R.string.localizable.onboarding_nickname_description)
-          .font(.pretendard(size: 16, weight: .regular))
-          .foregroundColor(Color(R.color.gray07))
-          .frame(maxWidth: .infinity, alignment: .leading)
-          .padding(.top, 12)
-          .padding(.leading, 16)
-        
-        Spacer().frame(height: 48)
-        
         TextField("ex. 러버", text: viewStore.binding(get: \.nickname, send: OnboardingCore.Action.nicknameEdited))
           .font(.pretendard(size: 18, weight: .regular))
           .foregroundColor(.black)

--- a/LoveBird/Sources/Root/Onboarding/OnboardingProfileView.swift
+++ b/LoveBird/Sources/Root/Onboarding/OnboardingProfileView.swift
@@ -15,7 +15,7 @@ struct OnboardingProfileView: View {
   @StateObject private var keyboard = KeyboardResponder()
   
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       VStack(alignment: .center) {
         ImagePickerView(use: "profile", selectedUIImage: $image, representImage: Image(R.image.ic_profile))
           .frame(width: 124, height: 124, alignment: .center)

--- a/LoveBird/Sources/Root/Onboarding/OnboardingProfileView.swift
+++ b/LoveBird/Sources/Root/Onboarding/OnboardingProfileView.swift
@@ -17,25 +17,8 @@ struct OnboardingProfileView: View {
   var body: some View {
     WithViewStore(self.store) { viewStore in
       VStack(alignment: .center) {
-        Spacer().frame(height: 24)
-        
-        Text(R.string.localizable.onboarding_profile_title)
-          .font(.pretendard(size: 20, weight: .bold))
-          .foregroundColor(.black)
-          .frame(maxWidth: .infinity, alignment: .leading)
-          .padding(.leading, 16)
-        
-        Text(R.string.localizable.onboarding_profile_description)
-          .font(.pretendard(size: 16, weight: .regular))
-          .foregroundColor(Color(R.color.gray07))
-          .frame(maxWidth: .infinity, alignment: .leading)
-          .padding(.top, 12)
-          .padding(.leading, 16)
-        
-        Spacer().frame(height: 48)
-        
-          ImagePickerView(use: "profile", selectedUIImage: $image, representImage: Image(R.image.ic_profile))
-            .frame(width: 124, height: 124, alignment: .center)
+        ImagePickerView(use: "profile", selectedUIImage: $image, representImage: Image(R.image.ic_profile))
+          .frame(width: 124, height: 124, alignment: .center)
         
         Spacer()
         

--- a/LoveBird/Sources/Root/Onboarding/OnboardingView.swift
+++ b/LoveBird/Sources/Root/Onboarding/OnboardingView.swift
@@ -16,7 +16,7 @@ struct OnboardingView: View {
   
   var body: some View {
     WithViewStore(self.store, observe: { $0 }) { viewStore in
-      VStack {
+      VStack(spacing: 0) {
         HStack(alignment: .center) {
           Button { viewStore.send(.previousTapped) } label: {
             Image(
@@ -42,13 +42,30 @@ struct OnboardingView: View {
           Button { viewStore.send(.nextTapped) } label: {
             Image(
               viewStore.page.isLast
-                ? R.image.ic_navigate_next_active
-                : R.image.ic_navigate_next_inactive
+                ? R.image.ic_navigate_next_inactive
+                : R.image.ic_navigate_next_active
             )
             .padding(.trailing, 16)
           }
         }
         .frame(width: UIScreen.width, height: 44)
+
+        Spacer(minLength: 24)
+
+        VStack(alignment: .leading, spacing: 12) {
+          Text(viewStore.state.pageState.title)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .font(.pretendard(size: 20, weight: .bold))
+            .foregroundColor(.black)
+
+          Text(R.string.localizable.onboarding_email_description)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .font(.pretendard(size: 16, weight: .regular))
+            .foregroundColor(Color(R.color.gray07))
+        }
+        .padding(.leading, 16)
+
+        Spacer(minLength: 48)
         
         Pager(page: viewStore.page, data: Page.Onboarding.allCases, id: \.self) {
           switch $0 {

--- a/LoveBird/Sources/Root/Onboarding/OnboardingView.swift
+++ b/LoveBird/Sources/Root/Onboarding/OnboardingView.swift
@@ -15,78 +15,58 @@ struct OnboardingView: View {
   let store: StoreOf<OnboardingCore>
   
   var body: some View {
-    WithViewStore(self.store) { viewStore in
+    WithViewStore(self.store, observe: { $0 }) { viewStore in
       VStack {
-        HStack {
+        HStack(alignment: .center) {
           Button { viewStore.send(.previousTapped) } label: {
-            Image(viewStore.page.isNickname
-                  ? R.image.ic_navigate_previous_inactive
-                  : R.image.ic_navigate_previous_active)
-            .offset(x: 16)
+            Image(
+              viewStore.page.isFisrt
+                ? R.image.ic_navigate_previous_inactive
+                : R.image.ic_navigate_previous_active
+            )
+            .padding(.leading, 16)
           }
           
           Spacer()
           
           HStack {
-            Circle()
-              .frame(width: 10, height: 10)
-              .foregroundColor(viewStore.page.index == 0 ? Color(R.color.primary) : Color(R.color.green164))
-            Circle()
-              .frame(width: 10, height: 10)
-              .foregroundColor(viewStore.page.index == 1 ? Color(R.color.primary) : Color(R.color.green164))
-            Circle()
-              .frame(width: 10, height: 10)
-              .foregroundColor(viewStore.page.index == 2 ? Color(R.color.primary) : Color(R.color.green164))
-            Circle()
-              .frame(width: 10, height: 10)
-              .foregroundColor(viewStore.page.index == 3 ? Color(R.color.primary) : Color(R.color.green164))
-            Circle()
-              .frame(width: 10, height: 10)
-              .foregroundColor(viewStore.page.index == 4 ? Color(R.color.primary) : Color(R.color.green164))
-            Circle()
-              .frame(width: 10, height: 10)
-              .foregroundColor(viewStore.page.index == 5 ? Color(R.color.primary) : Color(R.color.green164))
-            Circle()
-              .frame(width: 10, height: 10)
-              .foregroundColor(viewStore.page.index == 6 ? Color(R.color.primary) : Color(R.color.green164))
+            ForEach(Page.Onboarding.allCases, id: \.self) {
+              Circle()
+                .frame(width: 10, height: 10)
+                .foregroundColor(viewStore.page.index == $0.rawValue ? Color(R.color.primary) : Color(R.color.green164))
+            }
           }
           
           Spacer()
           
-          Button {
-            viewStore.send(.nextTapped)
-            self.hideKeyboard()
-          } label: {
-            Image(R.image.ic_navigate_next_active)
-            .offset(x: -16)
+          Button { viewStore.send(.nextTapped) } label: {
+            Image(
+              viewStore.page.isLast
+                ? R.image.ic_navigate_next_active
+                : R.image.ic_navigate_next_inactive
+            )
+            .padding(.trailing, 16)
           }
         }
         .frame(width: UIScreen.width, height: 44)
         
-        Pager(page: viewStore.page, data: [0, 1, 2, 3, 4, 5], id: \.self) { page in
-          if page as! Int == 0 {
+        Pager(page: viewStore.page, data: Page.Onboarding.allCases, id: \.self) {
+          switch $0 {
+          case .email:
             OnboardingEmailView(store: self.store)
-              .frame(maxWidth: .infinity, maxHeight: .infinity)
-          } else if page == 1 {
+          case .nickname:
             OnboardingNicknameView(store: self.store)
-              .frame(maxWidth: .infinity, maxHeight: .infinity)
-          } else if page == 2 {
+          case .profileImage:
             OnboardingProfileView(store: self.store)
-          } else if page == 3 {
+          case .birth:
             OnboardingBirthDateView(store: self.store)
-          } else if page == 4 {
+          case .gender:
             OnboardingGenderView(store: self.store)
-          } else if page == 5 {
+          case .anniversary:
             OnboardingDateView(store: self.store)
-              .frame(maxWidth: .infinity, maxHeight: .infinity)
           }
-//        else if page == 6 {
-//            OnboardingInvitationView(store: self.store)
-//              .frame(maxWidth: .infinity, maxHeight: .infinity)
-//          }
         }
         .allowsDragging(false)
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .edgesIgnoringSafeArea(.bottom)
       }
     }

--- a/LoveBird/Sources/Root/Onboarding/OnboardingView.swift
+++ b/LoveBird/Sources/Root/Onboarding/OnboardingView.swift
@@ -58,7 +58,7 @@ struct OnboardingView: View {
             .font(.pretendard(size: 20, weight: .bold))
             .foregroundColor(.black)
 
-          Text(R.string.localizable.onboarding_email_description)
+          Text(viewStore.state.pageState.description)
             .frame(maxWidth: .infinity, alignment: .leading)
             .font(.pretendard(size: 16, weight: .regular))
             .foregroundColor(Color(R.color.gray07))

--- a/LoveBird/Sources/Root/RootCore.swift
+++ b/LoveBird/Sources/Root/RootCore.swift
@@ -70,13 +70,14 @@ struct RootCore: Reducer {
           var rootState: State
 //          userData.remove(key: .accessToken)
 //          userData.remove(key: .refreshToken)
-          if user == nil {
-            rootState = .login(LoginCore.State())
-          } else if user?.partnerId == nil {
-            rootState = .coupleLink(CoupleLinkCore.State())
-          } else {
-            rootState = .mainTab(MainTabCore.State())
-          }
+//          if user == nil {
+//            rootState = .login(LoginCore.State())
+//          } else if user?.partnerId == nil {
+//            rootState = .coupleLink(CoupleLinkCore.State())
+//          } else {
+//            rootState = .mainTab(MainTabCore.State())
+//          }
+          rootState = .onboarding(OnboardingCore.State())
           await send(.updateRootState(rootState), animation: .default)
         }
         


### PR DESCRIPTION
### 구현 설명

기존 Indicator가 작동하지 않은 이유는 Page가 Class 이므로 내부 프로퍼티인 index 값이 바뀌어도 변경되었다, 즉 Equatable의 `==`가 무조건 true로 return 된다.
따라서 index가 변경되었을 때, State의 pageState를 변경함에 따라 변화를 감지하고 뷰를 다시 그려준다.

### 참고사항

OnboardingView 및 OnboardingCore를 리팩토링 하였음